### PR TITLE
Public order index

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,3 @@
 class ApplicationController < ActionController::Base
+  before_action :configure_permitted_parameters, if: :devise_controller?
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,2 @@
 class ApplicationController < ActionController::Base
-  before_action :configure_permitted_parameters, if: :devise_controller?
 end

--- a/app/controllers/public/orders_controller.rb
+++ b/app/controllers/public/orders_controller.rb
@@ -9,7 +9,7 @@ class Public::OrdersController < ApplicationController
     @order = Order.find(params[:id])
     @order_details = @order.order_details.all
     # 注文履歴の商品合計を出すため
-    @subtotals = @order_details.map { |order_detail| order_detail.price * order_detail.amount }
+    @subtotals = @order_details.map { |order_detail| order_detail.subtotal }
     @sum = @subtotals.sum
     @order.shipping_fee = 800
     @order_details = @order.order_details

--- a/app/controllers/public/orders_controller.rb
+++ b/app/controllers/public/orders_controller.rb
@@ -1,13 +1,15 @@
 class Public::OrdersController < ApplicationController
+  before_action :correct_customer, only: [:show]
+
   def index
-    @orders = Order.all
+    @orders = current_customer.orders
   end
 
   def show
     @order = Order.find(params[:id])
     @order_details = @order.order_details.all
     # 注文履歴の商品合計を出すため
-    @subtotals = @order_details.map { |order_detail| order_detail.subtotal }
+    @subtotals = @order_details.map { |order_detail| order_detail.price * order_detail.amount }
     @sum = @subtotals.sum
     @order.shipping_fee = 800
     @order_details = @order.order_details
@@ -72,4 +74,11 @@ class Public::OrdersController < ApplicationController
   def order_params
     params.require(:order).permit(:shipping_fee, :amount_billed, :payment_method, :postal_code, :shipping_address, :shipping_name)
   end
+
+  def correct_customer
+    @order = Order.find(params[:id])
+    @customer = @order.customer
+    redirect_to(public_items_path) unless @customer == current_customer
+  end
+
 end

--- a/app/views/admin/orders/index.html.erb
+++ b/app/views/admin/orders/index.html.erb
@@ -1,7 +1,7 @@
 <div class = "container">
     <div class = "col-sm-10 px-sm-0 mx-auto">
       <h4 class = "mb-5 text-center">注文履歴一覧</h4>
-      
+
       <table class="table table-hover teble-inverse my-5 mx-auto">
         <thead class = "table-secondary">
           <tr>
@@ -17,7 +17,7 @@
               <td>
                 <%= link_to admin_order_path(order) do %>
                 <%= order.created_at.strftime("%Y/%m/%d %H:%M") %>
-                <% end %>              
+                <% end %>
               </td>
               <td>
                 <%= order.customer.last_name %><%= order.customer.first_name %>
@@ -25,10 +25,10 @@
               <td>
                 <!--view内で個数計算-->
                 <% amounts = order.order_details.map { |order_detail| order_detail.amount } %>
-                <%= amounts.sum %>              
+                <%= amounts.sum %>
               </td>
               <td>
-                <%= order.order_status_i18n %>              
+                <%= order.order_status_i18n %>
               </td>
             <% end %>
             </tr>


### PR DESCRIPTION
注文履歴一覧をカレントユーザーのみの表示に修正しました。
また、urlに直打ちして他人の注文履歴詳細に移行しないようにしました。（リダイレクト先は商品一覧ページに設定しました。）
